### PR TITLE
Add className as a second argument instead of directly on the videoJsObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@ Due to how video.js mutates the DOM, integrating video.js with React can be a bi
 
 React Hooks helps us package this quite nicely, and all you have to do to use this package is:
 
-```
+```javascript
 import React from "react";
 import "video.js/dist/video-js.css";
-import { useVideoJS } from "react-hook-videojs";
+import { useVideoJS } from "react-hook-videojs";
 
 const App = () => {
   const videoUrl = "http://techslides.com/demos/sample-videos/small.mp4";
-  const { Video, player, ready } = useVideoJS({ sources: [{ src: videoUrl }] });
+  const className = "my-class";
+  const { Video, player, ready } = useVideoJS(
+    { sources: [{ src: videoUrl }] },
+    className // optional
+  );
   if (ready) {
-      // Do something with the video.js player object.
+    // Do something with the video.js player object.
   }
   return (
     <div className="App">
@@ -29,4 +33,7 @@ const App = () => {
 };
 ```
 
-`useVideoJS` takes a single options argument, and passes it without modifications to video.js. See their [options reference](https://docs.videojs.com/tutorial-options.html) for further information.
+`useVideoJS` takes an options argument, and passes it without modifications to video.js.
+You may also provide an optional second string argument that will be appended as class name on the `video` DOM node.
+
+See their [options reference](https://docs.videojs.com/tutorial-options.html) for further information on the options argument.

--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -14,7 +14,8 @@ const App = () => {
     controls,
     autoplay,
   };
-  const { Video, ready, player } = useVideoJS(videoJsOptions);
+  const className = "my-class";
+  const { Video, ready, player } = useVideoJS(videoJsOptions, className);
   console.log({ Video, ready, player });
   return (
     <>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,9 +1,7 @@
 import React, { useRef, useState, useEffect, useCallback } from "react";
 import videojs from "video.js";
 
-export const useVideoJS = (videoJsOptions) => {
-  const classNames = videoJsOptions.classNames || "";
-
+export const useVideoJS = (videoJsOptions, classNames = "") => {
   const videoNode = useRef(null);
   const [ready, setReady] = useState(false);
   const changedKey = JSON.stringify(videoJsOptions);


### PR DESCRIPTION
Adding the video DOM node to the videojsOptions object will include the class names as values to the options object passed to the `videojs` function. This means that if videojs ever were to include a `classNames` object, our use of `classNames` might cause a conflict.

Furthermore, I'm thinking about adding typescript support, and it would be easier if I would be able to use third party video.js types without modification.