### PR TITLE
Add support for children and props

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Due to how video.js mutates the DOM, integrating video.js with React can be a bi
 
 React Hooks helps us package this quite nicely, and all you have to do to use this package is:
 
-```javascript
+```jsx
 import React from "react";
 import "video.js/dist/video-js.css";
 import { useVideoJS } from "react-hook-videojs";
@@ -37,3 +37,38 @@ const App = () => {
 You may also provide an optional second string argument that will be appended as class name on the `video` DOM node.
 
 See their [options reference](https://docs.videojs.com/tutorial-options.html) for further information on the options argument.
+
+### Using with Tracks or other child components
+
+This hook now supports using features such as [tracks](https://docs.videojs.com/tutorial-tracks.html#text-tracks), and other child components of the `<video>` element.
+
+Example of using a text track:
+
+```jsx
+const App = () => {
+  // ...setup code from above
+
+  return (
+      <Video>
+        <track kind="captions" src="//example.com/path/to/captions.vtt" srclang="en" label="English" default />
+      </Video>
+  )
+}
+```
+
+_Note: Videojs supports adding `<track>` and `<sources>` elements programmatically_
+
+
+### Support for all `<video>` element attributes
+
+This hook supports all attributes for the native `<video>` element directly on the `<Video>` component.
+
+```jsx
+const App = () => {
+  return (
+    <Video muted autopictureinpicture />
+  )
+}
+```
+
+_Note: video.js supports many of these (and registration of listeners) through the player options_

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,10 @@
         "prettier": "^2.3.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+<<<<<<< HEAD
         "rimraf": "^3.0.2",
+=======
+>>>>>>> 77384b4... add children and props to useCallback
         "video.js": "^7.13.3",
         "vite": "^2.4.4"
       },
@@ -8690,15 +8693,24 @@
       }
     },
     "node_modules/eslint-plugin-react": {
+<<<<<<< HEAD
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.0.tgz",
       "integrity": "sha512-bZL+HeB+Qaimb4ryOc+OYYOX0XnOr6FX30ZXkzL8iSJA3tATTtZ1YgYyjK3jGvVDcZMejfUaeS/5wKDfTgyfVw==",
+=======
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",
+      "integrity": "sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==",
+>>>>>>> 77384b4... add children and props to useCallback
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
+<<<<<<< HEAD
         "estraverse": "^5.2.0",
+=======
+>>>>>>> 77384b4... add children and props to useCallback
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
@@ -8758,6 +8770,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+<<<<<<< HEAD
     "node_modules/eslint-plugin-react/node_modules/estraverse": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
@@ -8767,6 +8780,8 @@
         "node": ">=4.0"
       }
     },
+=======
+>>>>>>> 77384b4... add children and props to useCallback
     "node_modules/eslint-plugin-react/node_modules/has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,7 @@
         "prettier": "^2.3.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-<<<<<<< HEAD
         "rimraf": "^3.0.2",
-=======
->>>>>>> 77384b4... add children and props to useCallback
         "video.js": "^7.13.3",
         "vite": "^2.4.4"
       },
@@ -8693,24 +8690,15 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-<<<<<<< HEAD
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.0.tgz",
       "integrity": "sha512-bZL+HeB+Qaimb4ryOc+OYYOX0XnOr6FX30ZXkzL8iSJA3tATTtZ1YgYyjK3jGvVDcZMejfUaeS/5wKDfTgyfVw==",
-=======
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",
-      "integrity": "sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==",
->>>>>>> 77384b4... add children and props to useCallback
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
-<<<<<<< HEAD
         "estraverse": "^5.2.0",
-=======
->>>>>>> 77384b4... add children and props to useCallback
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
@@ -8770,7 +8758,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
     "node_modules/eslint-plugin-react/node_modules/estraverse": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
@@ -8780,8 +8767,6 @@
         "node": ">=4.0"
       }
     },
-=======
->>>>>>> 77384b4... add children and props to useCallback
     "node_modules/eslint-plugin-react/node_modules/has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,9 +17,11 @@ export const useVideoJS = (videoJsOptions, classNames = "") => {
   }, [changedKey]);
 
   const Video = useCallback(
-    () => (
+    ({children, ...props}) => (
       <div data-vjs-player key={changedKey}>
-        <video ref={videoNode} className={`video-js ${classNames}`} />
+        <video ref={videoNode} className={`video-js ${classNames}`} {...props} >
+          {children}
+        </video>
       </div>
     ),
     [changedKey]


### PR DESCRIPTION
Since videojs supports adding `<track>`, `<source>` elements, as well as `<video>` element attributes as part of its api, I figured it would be natural to offer that support in this hook as well.

This could be especially useful in cases where users want to use context providers or css-in-js hooks for these solutions. 